### PR TITLE
[feature] add gatewayHandle param to the settings form

### DIFF
--- a/example/load-3ds-card-minimal.js
+++ b/example/load-3ds-card-minimal.js
@@ -15,6 +15,8 @@ chargify.load({
   // points to your Chargify site
   serverHost: localStorage.getItem("serverHost"),
 
+  gatewayHandle: localStorage.getItem("gatewayHandle"),
+
   // Enable 3D secure
   threeDSecure: true,
 

--- a/example/load-apple-pay-full.js
+++ b/example/load-apple-pay-full.js
@@ -25,6 +25,8 @@ chargify.load({
   // points to your Chargify site
   serverHost: localStorage.getItem("serverHost"),
 
+  gatewayHandle: localStorage.getItem("gatewayHandle"),
+
   fields: {
     firstName: {
       selector: '#chargify-form',

--- a/example/load-apple-pay-minimal.js
+++ b/example/load-apple-pay-minimal.js
@@ -25,6 +25,8 @@ chargify.load({
 
   // points to your Chargify site
   serverHost: localStorage.getItem("serverHost"),
+
+  gatewayHandle: localStorage.getItem("gatewayHandle"),
 }, {
   onApplePayAuthorized: function () {
     document.querySelector('.host-form').dispatchEvent(new Event('submit')); // submit form

--- a/example/load-bank-full.js
+++ b/example/load-bank-full.js
@@ -16,6 +16,8 @@ chargify.load({
   // points to your Chargify site
   serverHost: localStorage.getItem("serverHost"),
 
+  gatewayHandle: localStorage.getItem("gatewayHandle"),
+
   // optional label/translation (i.e. '(optional field)')
   optionalLabel: '(optional field)',
 

--- a/example/load-bank-minimal.js
+++ b/example/load-bank-minimal.js
@@ -16,4 +16,5 @@ chargify.load({
   // points to your Chargify site
   serverHost: localStorage.getItem("serverHost"),
 
+  gatewayHandle: localStorage.getItem("gatewayHandle"),
 });

--- a/example/load-card-dropdowns.js
+++ b/example/load-card-dropdowns.js
@@ -15,6 +15,8 @@ chargify.load({
   // points to your Chargify site
   serverHost: localStorage.getItem("serverHost"),
 
+  gatewayHandle: localStorage.getItem("gatewayHandle"),
+
   // Enable 3D secure
   threeDSecure: true,
 

--- a/example/load-card-full-default-error-messages.js
+++ b/example/load-card-full-default-error-messages.js
@@ -16,6 +16,8 @@ chargify.load({
   // points to your Chargify site
   serverHost: localStorage.getItem("serverHost"),
 
+  gatewayHandle: localStorage.getItem("gatewayHandle"),
+
   // flag to show/hide the credit card image
   // true: hides the credit card image
   // visible otherwise

--- a/example/load-card-full.js
+++ b/example/load-card-full.js
@@ -16,6 +16,8 @@ chargify.load({
   // points to your Chargify site
   serverHost: localStorage.getItem("serverHost"),
 
+  gatewayHandle: localStorage.getItem("gatewayHandle"),
+
   // flag to show/hide the credit card image
   // true: hides the credit card image
   // visible otherwise

--- a/example/load-card-minimal.js
+++ b/example/load-card-minimal.js
@@ -15,4 +15,5 @@ chargify.load({
   // points to your Chargify site
   serverHost: localStorage.getItem("serverHost"),
 
+  gatewayHandle: localStorage.getItem("gatewayHandle")
 });

--- a/example/load-direct-debit.js
+++ b/example/load-direct-debit.js
@@ -18,4 +18,6 @@ chargify.load({
   type: 'direct_debit',
 
   serverHost: localStorage.getItem("serverHost"),
+
+  gatewayHandle: localStorage.getItem("gatewayHandle"),
 });

--- a/example/load-gocardless-full-billing-address.js
+++ b/example/load-gocardless-full-billing-address.js
@@ -34,6 +34,8 @@ chargify.load({
   // points to your Chargify site
   serverHost: localStorage.getItem("serverHost"),
 
+  gatewayHandle: localStorage.getItem("gatewayHandle"),
+
   fields: {
     firstName: {
       selector: '#chargify-form',

--- a/example/load-gocardless.js
+++ b/example/load-gocardless.js
@@ -33,4 +33,6 @@ chargify.load({
   // selectorForToggleIbanOrLocalDetails: '.cfy-field--bankIban',
   // points to your Chargify site
   serverHost: localStorage.getItem("serverHost"),
+
+  gatewayHandle: localStorage.getItem("gatewayHandle"),
 });

--- a/example/load-pay-pal-full.js
+++ b/example/load-pay-pal-full.js
@@ -21,6 +21,8 @@ chargify.load({
   // points to your Chargify site
   serverHost: localStorage.getItem("serverHost"),
 
+  gatewayHandle: localStorage.getItem("gatewayHandle"),
+
   // Use auto-populated dropdowns instead of plain text fields
   addressDropdowns: true,
 

--- a/example/load-pay-pal-minimal.js
+++ b/example/load-pay-pal-minimal.js
@@ -21,6 +21,8 @@ chargify.load({
 
   // points to your Chargify site
   serverHost: localStorage.getItem("serverHost"),
+
+  gatewayHandle: localStorage.getItem("gatewayHandle"),
 }, {
   onPayPalAuthorized: function () {
     document.querySelector('.host-form').dispatchEvent(new Event('submit')); // submit form

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
         <option value="load-apple-pay-full">Apple-pay-full</option>
         <option value="switchable-payment-types">Switchable-payment-types</option>
       </select> Example <br>
+      <input type="text" id="gateway-handle" class="settings-input" name="type"> Gateway Handle (optional)
       <div class="error" id="errors-box" style="display: none;">
         <span class="error-text">Fill fields</span><br>
       </div>

--- a/src/settings.js
+++ b/src/settings.js
@@ -2,6 +2,7 @@ var chargifyJsSrc = document.getElementById('chargify-js-src');
 var publicKey = document.getElementById('public-key');
 var serverHost = document.getElementById('server-host');
 var example = document.getElementById('examples');
+var gatewayHandle = document.getElementById('gateway-handle');
 var settingsSubmit = document.getElementById('settings-submit');
 var loadingSubmit = document.getElementById('settings-loading');
 var errorBox = document.getElementById('errors-box');
@@ -10,11 +11,13 @@ var chargifyJsSrcValue = localStorage.getItem("chargifyJsSrc");
 var publicKeyValue = localStorage.getItem("publicKey");
 var serverHostValue = localStorage.getItem("serverHost");
 var exampleValue = localStorage.getItem("example");
+var gatewayHandleValue = localStorage.getItem("gatewayHandle");
 
 chargifyJsSrc.value = chargifyJsSrcValue;
 publicKey.value = publicKeyValue;
 serverHost.value = serverHostValue;
 example.value = exampleValue;
+gatewayHandle.value = gatewayHandleValue;
 
 if(!chargifyJsSrc.value){
   chargifyJsSrc.value = 'https://js.chargify.com/latest/chargify.js';
@@ -31,6 +34,7 @@ saveSettings = () => {
   localStorage.setItem("publicKey", publicKey.value);
   localStorage.setItem("serverHost", serverHost.value);
   localStorage.setItem("example", example.value);
+  localStorage.setItem("gatewayHandle", gatewayHandle.value);
   location.reload();
 }
 


### PR DESCRIPTION
## WHY:
We need a way to provide `gatewayHandle` param to ch.js, it's used with MG8  [https://developers.chargify.com/docs/developer-docs/ZG9jOjE0NjAzNDIz-gateway-support#multiple-gateways-on-a-single-site](https://developers.chargify.com/docs/developer-docs/ZG9jOjE0NjAzNDIz-gateway-support#multiple-gateways-on-a-single-site)

usecase: testing https://github.com/chargify/chargify/pull/21106